### PR TITLE
Add OutRoadMB: outlier-based road geometry prioritizer

### DIFF
--- a/tools/prioritizers/OutRoadMB/Dockerfile
+++ b/tools/prioritizers/OutRoadMB/Dockerfile
@@ -1,0 +1,9 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+
+RUN pip install --no-cache-dir grpcio>=1.74.0 grpcio-tools>=1.74.0 numpy
+
+COPY . .
+
+ENTRYPOINT ["python", "main.py"]

--- a/tools/prioritizers/OutRoadMB/LICENSE.md
+++ b/tools/prioritizers/OutRoadMB/LICENSE.md
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Marcello Babbi (marcello.babbi@gmail.com).
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/tools/prioritizers/OutRoadMB/README.md
+++ b/tools/prioritizers/OutRoadMB/README.md
@@ -1,0 +1,85 @@
+# OutRoadMB
+
+**Outlier-based Road Geometry Prioritizer for Self-Driving Car Test Suites**
+
+## Approach
+
+OutRoadMB prioritizes SDC test cases by detecting **geometric outliers** in road shapes. The intuition: roads with unusual geometry (sharp turns, abnormal curvature, low safety margins) are more likely to trigger failures in the self-driving car simulator.
+
+### Feature Extraction
+
+For each test case, we extract 8 road geometry features:
+
+| # | Feature | Description |
+|---|---------|-------------|
+| F1 | Direct Distance | Euclidean distance between road start and end |
+| F2 | Road Distance | Total road segment length |
+| F6 | Total Angle | Sum of all angle changes along the road |
+| F9 | Max Angle | Maximum single angle change |
+| F11 | Mean Angle | Average angle change |
+| F8 | Std Angle | Standard deviation of angle changes |
+| F14 | Road Safety Sum | Total area between road curve and simplified polyline (inflection-point detection + Shoelace formula) |
+| F15 | Road Safety Mean | Mean safety area per road segment |
+
+### Outlier Detection
+
+Test cases are ranked by their distance from the feature-space centroid using one of two metrics:
+
+- **Mahalanobis distance** (default): accounts for feature correlations via inverse covariance matrix. More robust when features are correlated.
+- **Euclidean distance**: z-score normalized. Simpler, treats features as independent.
+
+Tests with the highest anomaly scores (most unusual road geometry) are prioritized first.
+
+### Why Unsupervised?
+
+The approach requires no training labels — it works entirely from road geometry. This makes it robust to distribution shifts across different test campaigns and generators (Frenetic, AmbiGen, etc.).
+
+## Available Strategies
+
+| Key | Description |
+|-----|-------------|
+| `mahalanobis-outlier-first` | **(default)** Mahalanobis distance outlier detection |
+| `euclidean-outlier-first` | Euclidean z-score outlier detection |
+| `less-safe-first` | Rank by road safety area (Shoelace deviation) |
+| `longest-first` | Baseline: most road points first |
+| `total-distance-first` | Baseline: longest road distance first |
+
+## Docker Image
+
+> **Pre-built image:** `marcellobabbi/outroadmb:latest`
+
+### Build locally
+
+```bash
+docker build -t outroadmb .
+```
+
+### Run
+
+```bash
+# Default strategy (mahalanobis-outlier-first)
+docker run --rm outroadmb -p 50051
+
+# Specific strategy
+docker run --rm outroadmb -p 50051 -s euclidean-outlier-first
+
+# Via environment variable
+docker run --rm -e STRATEGY=less-safe-first -e GRPC_PORT=50051 outroadmb
+```
+
+## Project Structure
+
+```
+OutRoadMB/
+├── main.py                     # gRPC server (CompetitionTool interface)
+├── strategies.py               # Domain logic: feature extraction + prioritization strategies
+├── competition_2026_pb2.py     # Generated protobuf stubs
+├── competition_2026_pb2_grpc.py# Generated gRPC stubs
+├── Dockerfile
+├── LICENSE.md
+└── README.md
+```
+
+## License
+
+MIT — see [LICENSE.md](LICENSE.md)

--- a/tools/prioritizers/OutRoadMB/main.py
+++ b/tools/prioritizers/OutRoadMB/main.py
@@ -1,0 +1,214 @@
+"""OutRoadMB — Outlier-based Road geometry prioritizer.
+
+gRPC Competition Tool implementing the CompetitionTool service interface.
+Delegates prioritization to domain-layer strategies that rank SDC test cases
+by road geometry anomaly — tests with unusual shapes (sharp turns, abnormal
+distances, low safety margins) are prioritized first to detect faults earlier.
+
+Approach:
+    1. Extract 8 road geometry features per test case (distance metrics,
+       angle statistics, road safety via inflection-point detection and
+       Shoelace formula).
+    2. Compute anomaly scores using outlier detection (Euclidean z-score
+       or Mahalanobis distance in feature space).
+    3. Return test cases ordered by decreasing anomaly score.
+
+The tool is unsupervised — it does not require training data from the
+Initialize phase, though it properly consumes the Oracle stream as
+required by the competition protocol.
+
+Authors: Marcello B.
+"""
+
+import os
+import sys
+import logging
+import argparse
+import time
+import concurrent.futures as fut
+
+import grpc
+import competition_2026_pb2
+import competition_2026_pb2_grpc
+
+from strategies import (
+    TestCaseData,
+    PrioritizationStrategy,
+    get_strategy,
+    available_strategies,
+    STRATEGY_REGISTRY,
+)
+
+# ---------------------------------------------------------------------------
+#   Logging
+# ---------------------------------------------------------------------------
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s  %(levelname)-8s  %(name)s — %(message)s",
+)
+logger = logging.getLogger("OutRoadMB")
+
+
+# ---------------------------------------------------------------------------
+#   Protobuf ↔ Domain Converters
+# ---------------------------------------------------------------------------
+def _sdc_test_case_to_domain(pb: competition_2026_pb2.SDCTestCase) -> TestCaseData:
+    """Convert a gRPC SDCTestCase message to our domain TestCaseData.
+
+    Mapping:
+        pb.testId           →  TestCaseData.test_id
+        pb.roadPoints[i].x  →  TestCaseData.road_points[i][0]
+        pb.roadPoints[i].y  →  TestCaseData.road_points[i][1]
+    """
+    road_points = [(pt.x, pt.y) for pt in pb.roadPoints]
+    return TestCaseData(test_id=pb.testId, road_points=road_points)
+
+
+# ---------------------------------------------------------------------------
+#   Oracle Store — holds initialization data from the evaluator
+# ---------------------------------------------------------------------------
+class OracleStore:
+    """Stores historical test results received during Initialize.
+
+    The evaluator sends Oracle messages containing:
+        - testCase (SDCTestCase): road geometry
+        - hasFailed (bool): whether the test detected a failure
+
+    This data can be used by strategies that benefit from training data
+    (e.g., supervised classifiers). Currently our strategies are unsupervised,
+    so we store the data for future extensibility but don't require it.
+    """
+
+    def __init__(self):
+        self.oracles: list[tuple[TestCaseData, bool]] = []
+
+    def ingest(self, oracle: competition_2026_pb2.Oracle):
+        tc = _sdc_test_case_to_domain(oracle.testCase)
+        self.oracles.append((tc, oracle.hasFailed))
+
+    def clear(self):
+        self.oracles.clear()
+
+    @property
+    def size(self) -> int:
+        return len(self.oracles)
+
+
+# ---------------------------------------------------------------------------
+#   gRPC Servicer — implements CompetitionToolServicer
+# ---------------------------------------------------------------------------
+class OutRoadMBServicer(competition_2026_pb2_grpc.CompetitionToolServicer):
+    """gRPC adapter that delegates prioritization to domain strategies.
+
+    Strategy selection:
+        Configured via --strategy CLI flag (or STRATEGY env var).
+        Defaults to 'mahalanobis-outlier-first'.
+    """
+
+    def __init__(self, strategy_name: str):
+        self.strategy_name = strategy_name
+        self.strategy: PrioritizationStrategy = get_strategy(strategy_name)
+        self.oracle_store = OracleStore()
+        logger.info(
+            "Servicer initialized — strategy='%s' (%s)",
+            strategy_name,
+            type(self.strategy).__name__,
+        )
+
+    def Name(self, request, context):
+        """Return tool name — used by the evaluator to identify us."""
+        return competition_2026_pb2.NameReply(name=f"OutRoadMB-{self.strategy_name}")
+
+    def Initialize(self, request_iterator, context):
+        """Ingest Oracle stream (historical test results as training data).
+
+        Required by competition protocol. We consume the full stream and
+        store oracle data for potential future use by supervised strategies.
+        """
+        self.oracle_store.clear()
+        count = 0
+        for oracle in request_iterator:
+            self.oracle_store.ingest(oracle)
+            count += 1
+
+        logger.info("Initialize complete — received %d oracle entries", count)
+        return competition_2026_pb2.InitializationReply(ok=True)
+
+    def Prioritize(self, request_iterator, context):
+        """Prioritize a stream of SDCTestCase messages.
+
+        Flow:
+            1. Consume the full input stream → List[SDCTestCase]
+            2. Convert protobuf → domain: SDCTestCase → TestCaseData
+            3. Delegate to strategy: strategy.prioritize(test_cases)
+            4. Yield PrioritizationReply in prioritized order
+        """
+        start = time.perf_counter()
+
+        # 1. Consume stream
+        pb_test_cases = list(request_iterator)
+
+        # 2. Convert protobuf → domain objects
+        domain_test_cases = [_sdc_test_case_to_domain(tc) for tc in pb_test_cases]
+
+        logger.info("Prioritize called — %d test cases", len(domain_test_cases))
+
+        # 3. Delegate to strategy
+        prioritized_ids: list[str] = self.strategy.prioritize(domain_test_cases)
+
+        elapsed = time.perf_counter() - start
+        logger.info("Prioritization complete in %.4fs", elapsed)
+
+        # 4. Yield results
+        for test_id in prioritized_ids:
+            yield competition_2026_pb2.PrioritizationReply(testId=test_id)
+
+
+# ---------------------------------------------------------------------------
+#   Server Bootstrap
+# ---------------------------------------------------------------------------
+def serve(port: str, strategy_name: str):
+    server = grpc.server(fut.ThreadPoolExecutor(max_workers=4))
+
+    servicer = OutRoadMBServicer(strategy_name)
+    competition_2026_pb2_grpc.add_CompetitionToolServicer_to_server(servicer, server)
+
+    bind_address = f"[::]:{port}"
+    server.add_insecure_port(bind_address)
+
+    logger.info("Starting gRPC server on %s", bind_address)
+    logger.info("Strategy: %s", strategy_name)
+    server.start()
+    logger.info("Server is running")
+
+    try:
+        server.wait_for_termination()
+    except KeyboardInterrupt:
+        logger.info("Shutting down...")
+        server.stop(grace=5)
+
+    logger.info("Server terminated")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description="OutRoadMB — SDC Test Prioritizer (gRPC Competition Tool)"
+    )
+    parser.add_argument(
+        "-p", "--port",
+        default=os.environ.get("GRPC_PORT", "50051"),
+        help="Port to listen on (default: 50051 or $GRPC_PORT)",
+    )
+    parser.add_argument(
+        "-s", "--strategy",
+        default=os.environ.get("STRATEGY", "mahalanobis-outlier-first"),
+        help="Prioritization strategy (default: mahalanobis-outlier-first)",
+    )
+    args = parser.parse_args()
+
+    if args.strategy not in STRATEGY_REGISTRY:
+        print(f"ERROR: Unknown strategy '{args.strategy}'")
+        print(f"Available: {', '.join(available_strategies())}")
+        sys.exit(1)
+
+    serve(port=args.port, strategy_name=args.strategy)

--- a/tools/prioritizers/OutRoadMB/strategies.py
+++ b/tools/prioritizers/OutRoadMB/strategies.py
@@ -1,0 +1,378 @@
+"""Prioritization strategies for SDC test suites.
+
+Implements the **Strategy Pattern** so that new prioritization algorithms
+can be added without modifying existing code (Open/Closed Principle).
+
+Adding a new strategy:
+    1. Create a class that inherits from ``PrioritizationStrategy``.
+    2. Implement the ``prioritize`` method.
+    3. Register it in ``STRATEGY_REGISTRY`` with a kebab-case key.
+
+Architecture note:
+    Strategies operate on ``TestCaseData`` – a lightweight, transport-
+    agnostic domain object.  This keeps the strategy logic decoupled from
+    both the REST layer (Pydantic models) and the gRPC layer (Protobuf),
+    allowing the same strategies to be reused across transport layers.
+"""
+
+import logging
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, List, Tuple, Type
+import math
+import numpy as np
+
+# =============================================================================
+#   Exceptions
+# =============================================================================
+class StrategyNotFoundError(Exception):
+    """Raised when the requested prioritization strategy does not exist."""
+    pass
+
+# =============================================================================
+#   Logger
+# =============================================================================
+logger = logging.getLogger(Path(__file__).stem)
+
+
+# =============================================================================
+#   Domain Object – transport-agnostic test case representation
+# =============================================================================
+@dataclass(frozen=True)
+class TestCaseData:
+    """Transport-agnostic domain object carrying raw road points for feature
+    implementation with gRPC.
+
+    Strategies receive full road data and compute  metrics they need internally.
+    This keeps strategies self-contained and allows new ones to be added
+    without modifying persistence or upload logic to meet Open/Closed
+    Principle.
+    """
+    test_id: str
+    road_points: List[Tuple[float, float]]  # ordered (x, y) pairs
+
+# =============================================================================
+#   Preparation Functions – Cross methods among strategies
+# =============================================================================
+
+def _simplify_by_inflection(pts: List[Tuple[float, float]]) -> List[int]:
+    """Find inflection points where road curvature changes sign.
+
+    Right-hand rule:
+        - positive cross-product means left turn (anti-clockwise)
+        - negative cross-product means right turn (clockwise)
+
+    Uses the signed cross product of consecutive displacement vectors.
+
+    A sign change marks a vertex of the simplified polyline.
+
+    Args:
+        pts: Road points as (x, y) tuples.
+
+    Returns:
+        Indices of inflection points (including start and end).
+    """
+    n = len(pts)
+    if n < 3:
+        return list(range(n))
+
+    vertices = [0]
+
+    # Initial turn direction
+    prev_cross = (
+        (pts[1][0] - pts[0][0]) * (pts[2][1] - pts[1][1])
+        - (pts[1][1] - pts[0][1]) * (pts[2][0] - pts[1][0])
+    )
+
+    for i in range(1, n - 1):
+        cross = (
+            (pts[i][0] - pts[i - 1][0]) * (pts[i + 1][1] - pts[i][1])
+            - (pts[i][1] - pts[i - 1][1]) * (pts[i + 1][0] - pts[i][0])
+        )
+
+        if cross == 0:
+            continue
+
+        # Sign change → inflection point
+        if prev_cross != 0 and (cross > 0) != (prev_cross > 0):
+            vertices.append(i)
+
+        prev_cross = cross
+
+    vertices.append(n - 1)
+    return vertices
+
+def _shoelace_area(points: List[Tuple[float, float]]) -> float:
+    """Compute polygon area via Shoelace formula
+        Ref: https://en.wikipedia.org/wiki/Shoelace_formula.
+
+    Used to measure the deviation between the actual road curve
+    and the simplified straight-line segment:
+        Ref: https://doi.org/10.48550/arXiv.2111.04666
+
+    Args:
+        points: Polygon vertices in order (auto-closed).
+
+    Returns:
+        Absolute area of the polygon.
+    """
+    n = len(points)
+    if n < 3:
+        return 0.0
+
+    area = 0.0
+    for i in range(n):
+        j = (i + 1) % n
+        # 2x2 Determinants computation over 2D-coordinates:
+        area += points[i][0] * points[j][1]
+        area -= points[j][0] * points[i][1]
+
+    return abs(area) / 2.0
+
+def extract_features(tc: TestCaseData, divide_pi: int = 18) -> List[float]:
+    """Extract road geometry features from a test case.
+
+    Features (from literature, Table 1 — Road Characteristics):
+        F1:  Direct Distance — Euclidean between start and finish
+        F2:  Road Distance   — Total road segment length
+        F6:  Total Angle     — Sum of all angle changes
+        F9:  Max Angle       — Maximum angle change
+        F11: Mean Angle      — Average angle change
+        F8:  Std Angle       — Std deviation of angle changes
+        F14: Road Safety Sum  — Total area between road and simplified polyline
+        F15: Road Safety Mean — Mean area per segment
+
+    Returns:
+        Feature vector [F1, F2, F6, F9, F11, F8, F14, F15]
+    """
+    pts = tc.road_points
+    n = len(pts)
+
+    # F1: Direct distance (start to finish)
+    direct_dist = math.sqrt(
+        (pts[-1][0] - pts[0][0]) ** 2 + (pts[-1][1] - pts[0][1]) ** 2
+    )
+
+    # F2: Road distance (total segment length)
+    road_dist = 0.0
+    for i in range(1, n):
+        dx = pts[i][0] - pts[i - 1][0]
+        dy = pts[i][1] - pts[i - 1][1]
+        road_dist += math.sqrt(dx * dx + dy * dy)
+
+    # Angles at each interior point
+    angles = []
+    for i in range(1, n - 1):
+        dx1 = pts[i][0] - pts[i - 1][0]
+        dy1 = pts[i][1] - pts[i - 1][1]
+        dx2 = pts[i + 1][0] - pts[i][0]
+        dy2 = pts[i + 1][1] - pts[i][1]
+
+        len1 = math.sqrt(dx1 * dx1 + dy1 * dy1)
+        len2 = math.sqrt(dx2 * dx2 + dy2 * dy2)
+
+        if len1 == 0 or len2 == 0:
+            angles.append(0.0)
+            continue
+
+        dot = dx1 * dx2 + dy1 * dy2
+        cos_a = max(-1.0, min(1.0, dot / (len1 * len2)))
+        angles.append(math.acos(cos_a))
+
+    if not angles:
+        total_angle = max_angle = mean_angle = std_angle = 0.0
+    else:
+        total_angle = sum(angles)
+        max_angle = max(angles)
+        mean_angle = total_angle / len(angles)
+        variance = sum((a - mean_angle) ** 2 for a in angles) / len(angles)
+        std_angle = math.sqrt(variance)
+
+    # F14, F15: Road Safety — area between road curve and simplified polyline
+    safety_sum = 0.0
+    safety_mean = 0.0
+    if n >= 3:
+        vertices = _simplify_by_inflection(pts)
+        areas = []
+        for i in range(len(vertices) - 1):
+            polygon_pts = [pts[j] for j in range(vertices[i], vertices[i + 1] + 1)]
+            if len(polygon_pts) >= 3:
+                areas.append(_shoelace_area(polygon_pts))
+            else:
+                areas.append(0.0)
+        safety_sum = sum(areas)
+        safety_mean = safety_sum / len(areas) if areas else 0.0
+
+    return [
+        direct_dist, road_dist, total_angle, max_angle,
+        mean_angle, std_angle, safety_sum, safety_mean,
+    ]
+
+# =============================================================================
+#   Strategy Base Class – Abstract Base Class for validation
+# =============================================================================
+class PrioritizationStrategy(ABC):
+    """Interface that every prioritization strategy must implement."""
+
+    @abstractmethod
+    def prioritize(self, test_cases: List[TestCaseData]) -> List[str]:
+        """Return test IDs ordered by this strategy's criterion.
+
+        Args:
+            test_cases: Unordered collection of test case metrics.
+
+        Returns:
+            List of ``test_id`` strings in prioritized order.
+        """
+
+
+# =============================================================================
+#   Strategies Logic - Our Strategies
+# =============================================================================
+class OutlierSortStrategy(PrioritizationStrategy):
+    """Sort tests by distance from mean in feature space — most anomalous first.
+
+    Supports two distance metrics:
+        - euclidean:    z-score normalize, then Euclidean from origin
+        - mahalanobis:  accounts for feature correlations via inverse covariance
+
+    Tests with unusual road geometry (sharp turns, abnormal distances)
+    score higher and are prioritized first — targeting likely failures.
+    """
+
+    def __init__(self, method: str = "euclidean") -> None:
+        self._method = method
+
+    def prioritize(self, test_cases: List[TestCaseData]) -> List[str]:
+        features = np.array([extract_features(tc) for tc in test_cases])
+        n, d = features.shape
+        mean = features.mean(axis=0) # mean over all tests
+        diffs = features - mean
+
+        if self._method == "euclidean":
+            stds = features.std(axis=0) # std over all tests
+            stds[stds == 0] = 1.0 # clip
+            z_scores = diffs / stds
+            distances = np.sqrt(np.sum(z_scores ** 2, axis=1))
+
+        elif self._method == "mahalanobis":
+            cov = np.cov(features, rowvar=False)
+            # Regularize for numerical stability (small sample / correlated features)
+            reg = 1e-6 * np.eye(d)
+            cov_inv = np.linalg.inv(cov + reg)
+            distances = np.sqrt(np.sum(diffs @ cov_inv * diffs, axis=1))
+
+        else:
+            raise ValueError(f"Unknown method: {self._method}")
+
+        order = np.argsort(-distances)
+        return [test_cases[i].test_id for i in order]
+
+
+class LessSafeStrategy(PrioritizationStrategy):
+    """Sort tests by safety sum value — least safe roads first.
+
+    Safety is measured as the total area between the actual road curve
+    and the simplified polyline through inflection points (Shoelace formula).
+    Higher area = more deviation from straight segments = less safe.
+    """
+    def prioritize(self, test_cases: List[TestCaseData]) -> List[str]:
+        safety_sums = []
+
+        for tc in test_cases:
+            pts = tc.road_points
+            n = len(pts)
+
+            if n >= 3:
+
+                vertices = _simplify_by_inflection(pts)
+                areas = []
+                for i in range(len(vertices) - 1):
+                    polygon_pts = [pts[j] for j in range(vertices[i], vertices[i + 1] + 1)]
+                    if len(polygon_pts) >= 3:
+                        areas.append(_shoelace_area(polygon_pts))
+                    else:
+                        areas.append(0.0)
+                safety_sum = sum(areas)
+                safety_sums.append(safety_sum)
+
+        order = np.argsort(-np.array(safety_sums))
+        return [test_cases[i].test_id for i in order]
+
+# =============================================================================
+#   Strategies Logic - Baseline
+# =============================================================================
+class LongestRoadFirstStrategy(PrioritizationStrategy):
+    """Prioritize test cases with the highest number of road points first."""
+
+    def prioritize(self, test_cases: List[TestCaseData]) -> List[str]:
+        sorted_cases = sorted(
+            test_cases,
+            key=lambda tc: len(tc.road_points),
+            reverse=True,
+        )
+        return [tc.test_id for tc in sorted_cases]
+
+
+class TotalDistanceFirstStrategy(PrioritizationStrategy):
+    """Prioritize test cases with the highest total geometric distance first."""
+
+    def prioritize(self, test_cases: List[TestCaseData]) -> List[str]:
+        sorted_cases = sorted(
+            test_cases,
+            key=lambda tc: self._total_distance(tc),
+            reverse=True,
+        )
+        return [tc.test_id for tc in sorted_cases]
+
+    @staticmethod
+    def _total_distance(tc: TestCaseData) -> float:
+        total = 0.0
+        pts = tc.road_points
+        for i in range(1, len(pts)):
+            dx = pts[i][0] - pts[i - 1][0]
+            dy = pts[i][1] - pts[i - 1][1]
+            total += math.sqrt(dx * dx + dy * dy)
+        return total
+
+
+# =============================================================================
+#   Strategy Registry
+# =============================================================================
+STRATEGY_REGISTRY: Dict[str, Type[PrioritizationStrategy]] = {
+    "longest-first": LongestRoadFirstStrategy,
+    "total-distance-first": TotalDistanceFirstStrategy,
+    "euclidean-outlier-first": lambda: OutlierSortStrategy("euclidean"),
+    "mahalanobis-outlier-first": lambda: OutlierSortStrategy("mahalanobis"),
+    "less-safe-first": LessSafeStrategy
+}
+
+
+def get_strategy(name: str) -> PrioritizationStrategy:
+    """Look up and instantiate a strategy by its registered name.
+
+    Args:
+        name: Kebab-case strategy identifier (e.g. ``"longest-first"``).
+
+    Returns:
+        An instance of the requested strategy.
+
+    Raises:
+        StrategyNotFoundError: If the name is not in the registry.
+    """
+
+    strategy_class = STRATEGY_REGISTRY.get(name)
+    if strategy_class is None:
+        available = ", ".join(sorted(STRATEGY_REGISTRY.keys()))
+        raise StrategyNotFoundError(
+            f"Unknown strategy '{name}'. Available strategies: {available}"
+        )
+
+    logger.debug("Resolved strategy '%s' → %s", name, strategy_class.__name__)
+    return strategy_class()
+
+
+def available_strategies() -> List[str]:
+    """Return the list of registered strategy names."""
+    return sorted(STRATEGY_REGISTRY.keys())


### PR DESCRIPTION
OutRoadMB — Outlier-based Road Geometry Prioritizer
Prioritizes SDC test cases by detecting geometric outliers in road shapes using Mahalanobis distance on an 8-feature vector (distance metrics, angle statistics, road safety via Shoelace formula).

Docker image: docker.io/marcellobabbi/outroadmb:latest
License: MIT
Strategy: Unsupervised (no training data required)